### PR TITLE
Add activeAt to Resident table, implement HeartChallenge quorums

### DIFF
--- a/.manifest/chores-development.yaml
+++ b/.manifest/chores-development.yaml
@@ -21,10 +21,6 @@ features:
       description: Delete a chore
       usage_hint: "[name]"
       should_escape: true
-    - command: /chores-list
-      url: https://zaratan.ngrok.io/slack/events
-      description: List current chores
-      should_escape: true
     - command: /chores-channel
       url: https://zaratan.ngrok.io/slack/events
       description: Set the claims channel

--- a/.manifest/chores-development.yaml
+++ b/.manifest/chores-development.yaml
@@ -26,10 +26,6 @@ features:
       description: Set the claims channel
       usage_hint: "[name]"
       should_escape: true
-    - command: /chores-sync
-      url: https://zaratan.ngrok.io/slack/events
-      description: Update the active members
-      should_escape: true
 oauth_config:
   redirect_urls:
     - https://zaratan.ngrok.io/slack/oauth_redirect

--- a/.manifest/chores-production.yaml
+++ b/.manifest/chores-production.yaml
@@ -26,10 +26,6 @@ features:
       description: Set the claims channel
       usage_hint: "[name]"
       should_escape: true
-    - command: /chores-sync
-      url: https://chores.mirror.zaratan.world/slack/events
-      description: Update the active members
-      should_escape: true
 oauth_config:
   redirect_urls:
     - https://chores.mirror.zaratan.world/slack/oauth_redirect

--- a/.manifest/chores-production.yaml
+++ b/.manifest/chores-production.yaml
@@ -21,10 +21,6 @@ features:
       description: Delete a chore
       usage_hint: "[name]"
       should_escape: true
-    - command: /chores-list
-      url: https://chores.mirror.zaratan.world/slack/events
-      description: List current chores
-      should_escape: true
     - command: /chores-channel
       url: https://chores.mirror.zaratan.world/slack/events
       description: Set the claims channel

--- a/.manifest/hearts-development.yaml
+++ b/.manifest/hearts-development.yaml
@@ -17,10 +17,6 @@ features:
       description: Set the hearts channel
       usage_hint: "[name]"
       should_escape: true
-    - command: /hearts-sync
-      url: https://zaratan.ngrok.io/slack/events
-      description: Update the active members
-      should_escape: true
 oauth_config:
   redirect_urls:
     - https://zaratan.ngrok.io/slack/oauth_redirect

--- a/.manifest/hearts-production.yaml
+++ b/.manifest/hearts-production.yaml
@@ -17,10 +17,6 @@ features:
       description: Set the hearts channel
       usage_hint: "[name]"
       should_escape: true
-    - command: /hearts-sync
-      url: https://hearts.mirror.zaratan.world/slack/events
-      description: Update the active members
-      should_escape: true
 oauth_config:
   redirect_urls:
     - https://hearts.mirror.zaratan.world/slack/oauth_redirect

--- a/migrations/20221111002600_update_resident.js
+++ b/migrations/20221111002600_update_resident.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('Resident', function(t) {
+    t.timestamp('activeAt');
+    t.dropColumn('name');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('Resident', function(t) {
+    t.dropColumn('activeAt');
+    t.string('name');
+  });
+};

--- a/migrations/20221114145719_update_heart_challenge.js
+++ b/migrations/20221114145719_update_heart_challenge.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+ exports.up = function(knex) {
+  return knex.schema.alterTable('HeartChallenge', function(t) {
+    t.timestamp('challengedAt').notNull();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('HeartChallenge', function(t) {
+    t.dropNullable('challengedAt');
+    t.dropColumn('challengedAt');
+  });
+};

--- a/migrations/20221115155124_update_chore_claim.js
+++ b/migrations/20221115155124_update_chore_claim.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+ exports.up = function(knex) {
+  return knex.schema.alterTable('ChoreClaim', function(t) {
+    t.string('houseId').references('House.slackId');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('ChoreClaim', function(t) {
+    t.dropColumn('houseId');
+  });
+};

--- a/src/bolt/blocks.js
+++ b/src/bolt/blocks.js
@@ -6,7 +6,6 @@ const {
   pointsPerResident,
   pointPrecision,
   achievementBase,
-  heartsMinVotesInitial,
   thingsMinVotesScalar,
   choresPollLength,
   thingsPollLength,
@@ -396,7 +395,7 @@ exports.heartsChallengeView = function () {
         type: 'input',
         label: { type: 'plain_text', text: 'Challengee', emoji: true },
         element: {
-          type: 'multi_users_select',
+          type: 'users_select',
           placeholder: { type: 'plain_text', text: 'Choose a resident', emoji: true },
           action_id: 'challengee'
         }
@@ -405,8 +404,14 @@ exports.heartsChallengeView = function () {
         type: 'input',
         label: { type: 'plain_text', text: 'Number of hearts', emoji: true },
         element: {
-          type: 'plain_text_input',
-          placeholder: { type: 'plain_text', text: 'Enter a number', emoji: true },
+          type: 'static_select',
+          placeholder: { type: 'plain_text', text: 'Select a number', emoji: true },
+          options: [
+            { text: { type: 'plain_text', text: '1', emoji: true }, value: '1' },
+            { text: { type: 'plain_text', text: '2', emoji: true }, value: '2' },
+            { text: { type: 'plain_text', text: '3', emoji: true }, value: '3' }
+          ],
+          initial_option: { text: { type: 'plain_text', text: '1', emoji: true }, value: '1' },
           action_id: 'hearts'
         }
       },
@@ -424,10 +429,10 @@ exports.heartsChallengeView = function () {
   };
 };
 
-exports.heartsChallengeCallbackView = function (challenge, circumstance) {
+exports.heartsChallengeCallbackView = function (challenge, quorum, circumstance) {
   const textA = `*<@${challenge.challengerId}>* challenged *<@${challenge.challengeeId}>* ` +
     `for *${challenge.value} heart(s)*, due to the following circumstance:`;
-  const textB = `*${heartsMinVotesInitial} endorsements* are required to pass, ` +
+  const textB = `*${quorum} endorsements* are required to pass, ` +
     `voting closes in *${heartsPollLength / HOUR} hours*`;
 
   return [

--- a/src/bolt/blocks.js
+++ b/src/bolt/blocks.js
@@ -263,7 +263,8 @@ exports.formatThing = function (thing) {
 };
 
 exports.thingsHomeView = function (balance) {
-  const textA = 'We use Things to spend money together.\n\n' +
+  const docsURI = 'https://github.com/kronosapiens/mirror/wiki/Things';
+  const textA = `We use *<${docsURI}|Things>* to spend money together.\n\n` +
     'Anyone can propose a buy, which requires *one* thumbs-up vote per $50. ' +
     'Successful buys are fulfilled within 3-7 days.';
 
@@ -349,7 +350,8 @@ exports.heartEmoji = function (numHearts) {
 };
 
 exports.heartsHomeView = function (numHearts) {
-  const textA = 'We use Hearts to keep each other accountable.\n\n' +
+  const docsURI = 'https://github.com/kronosapiens/mirror/wiki/Hearts';
+  const textA = `We use *<${docsURI}|Hearts>* to keep each other accountable.\n\n` +
     'Everyone starts with five hearts. We lose hearts when we fail to uphold our commitments, ' +
     'and we earn them back over time (one per month), and by exceeding expectations.';
 

--- a/src/bolt/blocks.js
+++ b/src/bolt/blocks.js
@@ -365,8 +365,8 @@ exports.heartsHomeView = function (numHearts) {
       {
         type: 'actions',
         elements: [
-          { type: 'button', action_id: 'hearts-challenge', text: { type: 'plain_text', text: 'Issue a challenge', emoji: true } },
-          { type: 'button', action_id: 'hearts-board', text: { type: 'plain_text', text: 'See current hearts', emoji: true } }
+          { type: 'button', action_id: 'hearts-board', text: { type: 'plain_text', text: 'See current hearts', emoji: true } },
+          { type: 'button', action_id: 'hearts-challenge', text: { type: 'plain_text', text: 'Issue a challenge', emoji: true } }
         ]
       }
     ]

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -78,8 +78,8 @@ app.event('app_home_opened', async ({ body, event }) => {
     await app.client.views.publish(data);
 
     // This bookkeeping is done asynchronously after returning the view
-    await Chores.addChorePenalty(houseId, residentId, now);
     await Chores.resolveChoreClaims(houseId, now);
+    await Chores.addChorePenalty(houseId, residentId, now);
   }
 });
 

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -169,17 +169,6 @@ app.command('/chores-del', async ({ ack, command }) => {
   await app.client.chat.postEphemeral(message);
 });
 
-app.command('/chores-list', async ({ ack, command }) => {
-  await ack();
-
-  const choresRankings = await Chores.getCurrentChoreRankings(command.team_id);
-  const parsedChores = choresRankings.map((chore) => `\n${chore.name} (${chore.ranking.toFixed(2)})`);
-
-  const text = `The current chores and their priority (adding up to 1):${parsedChores}`;
-  const message = prepareEphemeral(command, text);
-  await app.client.chat.postEphemeral(message);
-});
-
 app.command('/chores-sync', async ({ ack, command }) => {
   await ack();
 

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -79,7 +79,7 @@ app.event('app_home_opened', async ({ body, event }) => {
 
     // This bookkeeping is done asynchronously after returning the view
     await Chores.resolveChoreClaims(houseId, now);
-    await Chores.addChorePenalty(houseId, residentId, now);
+    // await Chores.addChorePenalty(houseId, residentId, now);
   }
 });
 

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -235,7 +235,7 @@ app.view('chores-claim-callback', async ({ ack, body }) => {
   const recentPoints = await Chores.getChorePoints(residentId, choreId, sixMonths, now);
 
   // Perform the claim
-  const [ claim ] = await Chores.claimChore(choreId, residentId, now);
+  const [ claim ] = await Chores.claimChore(houseId, choreId, residentId, now);
   await Polls.submitVote(claim.pollId, residentId, now, YAY);
 
   const message = {

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -61,10 +61,11 @@ app.event('app_home_opened', async ({ body, event }) => {
     const houseId = body.team_id;
     const residentId = event.user;
 
-    await Admin.addResident(houseId, residentId);
+    const now = new Date();
+
+    await Admin.addResident(houseId, residentId, now);
     console.log(`Added resident ${residentId}`);
 
-    const now = new Date();
     const monthStart = getMonthStart(now);
     const chorePoints = await Chores.getAllChorePoints(residentId, monthStart, now);
     const activePercentage = await Chores.getActiveResidentPercentage(residentId, now);
@@ -184,14 +185,18 @@ app.command('/chores-sync', async ({ ack, command }) => {
 
   const SLACKBOT = 'USLACKBOT';
 
+  const now = new Date();
   const workspaceMembers = await app.client.users.list({ token: choresOauth.bot.token });
 
   for (const member of workspaceMembers.members) {
     if (!member.is_bot & member.id !== SLACKBOT) {
-      await Admin.updateResident(member.team_id, member.id, !member.deleted, member.real_name);
+      member.deleted
+        ? await Admin.deleteResident(member.team_id, member.id)
+        : await Admin.addResident(member.team_id, member.id, now);
     }
   }
 
+  await sleep(5);
   const residents = await Admin.getResidents(workspaceMembers.members[0].team_id);
 
   const text = `Synced workspace, ${residents.length} active residents found`;

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -77,9 +77,9 @@ app.event('app_home_opened', async ({ body, event }) => {
     };
     await app.client.views.publish(data);
 
-    // This bookkeeping is done asynchronously
-    // TODO: resolve chore claims
+    // This bookkeeping is done asynchronously after returning the view
     await Chores.addChorePenalty(houseId, residentId, now);
+    await Chores.resolveChoreClaims(houseId, now);
   }
 });
 

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -65,7 +65,6 @@ app.event('app_home_opened', async ({ body, event }) => {
     console.log(`Added resident ${residentId}`);
 
     const now = new Date();
-
     await Hearts.initialiseResident(houseId, residentId, now);
     await sleep(5);
     await Hearts.regenerateHearts(houseId, residentId, now);
@@ -140,29 +139,6 @@ app.command('/hearts-channel', async ({ ack, command }) => {
     text = 'Only admins can set the channels...';
   }
 
-  const message = prepareEphemeral(command, text);
-  await app.client.chat.postEphemeral(message);
-});
-
-app.command('/hearts-sync', async ({ ack, command }) => {
-  await ack();
-
-  const SLACKBOT = 'USLACKBOT';
-
-  const now = new Date();
-  const houseId = command.team_id;
-  const workspaceMembers = await app.client.users.list({ token: heartsOauth.bot.token });
-
-  for (const member of workspaceMembers.members) {
-    if (!member.is_bot & member.id !== SLACKBOT) {
-      await Admin.updateResident(houseId, member.id, !member.deleted, member.real_name);
-      await Hearts.initialiseResident(houseId, member.id, now);
-    }
-  }
-
-  const residents = await Admin.getResidents(houseId);
-
-  const text = `Synced workspace, ${residents.length} active residents found`;
   const message = prepareEphemeral(command, text);
   await app.client.chat.postEphemeral(message);
 });

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -26,7 +26,7 @@ const home = {
 };
 
 const app = new App({
-  logLevel: LogLevel.DEBUG,
+  logLevel: LogLevel.INFO,
   clientId: process.env.HEARTS_CLIENT_ID,
   clientSecret: process.env.HEARTS_CLIENT_SECRET,
   signingSecret: process.env.HEARTS_SIGNING_SECRET,

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -80,7 +80,9 @@ app.event('app_home_opened', async ({ body, event }) => {
     };
     res = await app.client.views.publish(data);
 
-    // This bookkeeping is done asynchronously
+    // This bookkeeping is done asynchronously after returning the view
+    await Hearts.resolveChallenges(houseId, now);
+
     const [ karmaHeart ] = await Hearts.generateKarmaHeart(houseId, now);
     if (karmaHeart !== undefined) {
       const { heartsChannel } = await Admin.getHouse(houseId);
@@ -91,12 +93,6 @@ app.event('app_home_opened', async ({ body, event }) => {
       };
       res = await app.client.chat.postMessage(message);
     }
-
-    // const resolvableChallenges = await Hearts.getResolvableHeartChallenges(houseId, now);
-    // for (const challenge of resolvableChallenges) {
-    //   await Hearts.resolveHeartChallenge(challenge.id, now);
-    //   console.log(`Resolved HeartChallenge ${challenge.id}`);
-    // }
   }
 });
 

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -61,10 +61,11 @@ app.event('app_home_opened', async ({ body, event }) => {
     const houseId = body.team_id;
     const residentId = event.user;
 
-    await Admin.addResident(houseId, residentId);
+    const now = new Date();
+
+    await Admin.addResident(houseId, residentId, now);
     console.log(`Added resident ${residentId}`);
 
-    const now = new Date();
     await Hearts.initialiseResident(houseId, residentId, now);
     await sleep(5);
     await Hearts.regenerateHearts(houseId, residentId, now);

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -67,7 +67,7 @@ app.event('app_home_opened', async ({ body, event }) => {
     await Hearts.initialiseResident(houseId, residentId, now);
     await sleep(5);
 
-    const hearts = await Hearts.getHearts(houseId, residentId, now);
+    const hearts = await Hearts.getHearts(residentId, now);
 
     const data = {
       token: heartsOauth.bot.token,

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -74,13 +74,8 @@ app.event('app_home_opened', async ({ body, event }) => {
     };
     await app.client.views.publish(data);
 
-    // TODO: fix this
-    // This is where we resolve any buys, transparently to the resident
-    // const resolvableBuys = await Things.getResolvableThingBuys(houseId, now);
-    // for (const buy of resolvableBuys) {
-    //   await Things.resolveThingBuy(buy.id, now);
-    //   console.log(`Resolved ThingBuy ${buy.id}`);
-    // }
+    // This bookkeeping is done asynchronously after returning the view
+    await Things.resolveThingBuys(houseId, now);
   }
 });
 

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -60,10 +60,11 @@ app.event('app_home_opened', async ({ body, event }) => {
     const houseId = body.team_id;
     const residentId = event.user;
 
-    await Admin.addResident(houseId, residentId);
+    const now = new Date();
+
+    await Admin.addResident(houseId, residentId, now);
     console.log(`Added resident ${residentId}`);
 
-    const now = new Date();
     const balance = await Things.getHouseBalance(houseId, now);
 
     const data = {

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -63,8 +63,6 @@ app.event('app_home_opened', async ({ body, event }) => {
     const now = new Date();
 
     await Admin.addResident(houseId, residentId, now);
-    console.log(`Added resident ${residentId}`);
-
     const balance = await Things.getHouseBalance(houseId, now);
 
     const data = {

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -26,7 +26,7 @@ const home = {
 };
 
 const app = new App({
-  logLevel: LogLevel.DEBUG,
+  logLevel: LogLevel.INFO,
   clientId: process.env.THINGS_CLIENT_ID,
   clientSecret: process.env.THINGS_CLIENT_SECRET,
   signingSecret: process.env.THINGS_SIGNING_SECRET,

--- a/src/config.js
+++ b/src/config.js
@@ -17,8 +17,9 @@ exports.implicitPref = 0.25;
 exports.heartsPollLength = 3 * DAY;
 exports.heartsBaseline = 5;
 exports.heartsRegen = 0.5;
-exports.heartsMinVotesInitial = 4; // For removing initial hearts
-exports.heartsMinVotesFinal = 7; // For removing the final two hearts
+exports.heartsMinPctInitial = 0.4; // For removing initial hearts
+exports.heartsMinPctFinal = 0.7; // For removing the final two hearts
+exports.heartsCriticalNum = 2;
 exports.karmaDelay = 3 * HOUR;
 exports.karmaMaxHearts = 7;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,3 +5,5 @@ exports.DAY = 24 * exports.HOUR;
 exports.NAY = 0;
 exports.YAY = 1;
 exports.CANCEL = undefined;
+
+exports.SLACKBOT = 'USLACKBOT';

--- a/src/modules/chores.js
+++ b/src/modules/chores.js
@@ -335,9 +335,9 @@ exports.addChorePenalty = async function (houseId, residentId, currentTime) {
   const penaltyTime = new Date(monthStart.getTime() + penaltyDelay);
   if (currentTime < penaltyTime) { return []; }
 
-  const penalty = await Hearts.getHeart(houseId, residentId, penaltyTime);
+  const penalty = await Hearts.getHeart(residentId, penaltyTime);
   if (penalty === undefined) {
-    const hearts = await Hearts.getHearts(houseId, residentId, penaltyTime);
+    const hearts = await Hearts.getHearts(residentId, penaltyTime);
     if (hearts.sum === null) { return []; } // Don't penalize if not initialized
 
     const penaltyAmount = await exports.calculatePenalty(residentId, penaltyTime);

--- a/src/modules/chores.js
+++ b/src/modules/chores.js
@@ -239,6 +239,20 @@ exports.resolveChoreClaim = async function (claimId, resolvedAt) {
     .returning('*');
 };
 
+exports.resolveChoreClaims = async function (houseId, currentTime) {
+  const resolvableChoreClaims = await db('ChoreClaim')
+    .join('Resident', 'ChoreClaim.claimedBy', 'Resident.slackId')
+    .join('Poll', 'ChoreClaim.pollId', 'Poll.id')
+    .where('Resident.houseId', houseId)
+    .where('ChoreClaim.resolvedAt', null)
+    .where('Poll.endTime', '<=', currentTime)
+    .select('ChoreClaim.id');
+
+  for (const choreClaim of resolvableChoreClaims) {
+    await exports.resolveChoreClaim(choreClaim.id, currentTime);
+  }
+};
+
 exports.getChorePoints = async function (residentId, choreId, startTime, endTime) {
   return db('ChoreClaim')
     .where({ claimedBy: residentId, choreId: choreId, valid: true })

--- a/src/modules/chores.js
+++ b/src/modules/chores.js
@@ -200,7 +200,7 @@ exports.getValidChoreClaims = async function (choreId) {
     .andWhere({ choreId });
 };
 
-exports.claimChore = async function (choreId, slackId, claimedAt) {
+exports.claimChore = async function (houseId, choreId, slackId, claimedAt) {
   const choreValue = await exports.getCurrentChoreValue(choreId, claimedAt);
 
   if (choreValue.sum === null) { throw new Error('Cannot claim a zero-value chore!'); }
@@ -209,6 +209,7 @@ exports.claimChore = async function (choreId, slackId, claimedAt) {
 
   return db('ChoreClaim')
     .insert({
+      houseId: houseId,
       choreId: choreId,
       claimedBy: slackId,
       claimedAt: claimedAt,
@@ -241,9 +242,8 @@ exports.resolveChoreClaim = async function (claimId, resolvedAt) {
 
 exports.resolveChoreClaims = async function (houseId, currentTime) {
   const resolvableChoreClaims = await db('ChoreClaim')
-    .join('Resident', 'ChoreClaim.claimedBy', 'Resident.slackId')
     .join('Poll', 'ChoreClaim.pollId', 'Poll.id')
-    .where('Resident.houseId', houseId)
+    .where('ChoreClaim.houseId', houseId)
     .where('ChoreClaim.resolvedAt', null)
     .where('Poll.endTime', '<=', currentTime)
     .select('ChoreClaim.id');

--- a/src/modules/hearts.js
+++ b/src/modules/hearts.js
@@ -114,6 +114,19 @@ exports.resolveChallenge = async function (challengeId, resolvedAt) {
     .returning('*');
 };
 
+exports.resolveChallenges = async function (houseId, currentTime) {
+  const resolvableChallenges = await db('HeartChallenge')
+    .join('Poll', 'HeartChallenge.pollId', 'Poll.id')
+    .where('HeartChallenge.houseId', houseId)
+    .where('Poll.endTime', '<=', currentTime)
+    .where('HeartChallenge.resolvedAt', null)
+    .select('HeartChallenge.id');
+
+  for (const challenge of resolvableChallenges) {
+    await exports.resolveChallenge(challenge.id, currentTime);
+  }
+};
+
 // Karma
 
 exports.getKarma = async function (houseId, startTime, endTime) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,10 @@ exports.sleep = function (ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 };
 
+exports.getDateStart = function (date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+};
+
 exports.getMonthStart = function (date) {
   return new Date(date.getFullYear(), date.getMonth(), 1);
 };

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -5,7 +5,7 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
 const { HOUR } = require('../src/constants');
-const { sleep, getMonthStart, getMonthEnd, getNextMonthStart, getPrevMonthEnd } = require('../src/utils');
+const { sleep, getMonthStart, getMonthEnd, getNextMonthStart, getPrevMonthEnd, getDateStart } = require('../src/utils');
 const { db } = require('../src/db');
 
 const Admin = require('../src/modules/admin');
@@ -178,6 +178,10 @@ describe('Admin', async () => {
       expect(getNextMonthStart(feb1).getTime()).to.equal(mar1.getTime());
       expect(getNextMonthStart(feb14).getTime()).to.equal(mar1.getTime());
       expect(getNextMonthStart(feb28).getTime()).to.equal(mar1.getTime());
+
+      expect(getDateStart(now).getHours()).to.equal(0);
+      expect(getDateStart(now).getMinutes()).to.equal(0);
+      expect(getDateStart(now).getSeconds()).to.equal(0);
     });
   });
 });

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -61,8 +61,8 @@ describe('Chores', async () => {
 
   describe('managing chore preferences', async () => {
     beforeEach(async () => {
-      await Admin.addResident(HOUSE, RESIDENT1);
-      await Admin.addResident(HOUSE, RESIDENT2);
+      await Admin.addResident(HOUSE, RESIDENT1, now);
+      await Admin.addResident(HOUSE, RESIDENT2, now);
     });
 
     it('can list the existing chores', async () => {
@@ -95,7 +95,7 @@ describe('Chores', async () => {
         { choreId: sweeping.id, valuedAt: now, value: 20, ranking: 0, residents: 0 }
       ]);
 
-      const soon = new Date(now.getTime() + MINUTE);
+      const soon = new Date(now.getTime() + HOUR);
 
       const choreValues = await Chores.getCurrentChoreValues(HOUSE, soon);
       expect(choreValues.find(x => x.id === dishes.id).value).to.equal(15);
@@ -122,7 +122,7 @@ describe('Chores', async () => {
     });
 
     it('can query for active chore preferences', async () => {
-      await Admin.addResident(HOUSE, RESIDENT3);
+      await Admin.addResident(HOUSE, RESIDENT3, now);
       await sleep(5);
 
       await Chores.setChorePreference(HOUSE, RESIDENT1, dishes.id, sweeping.id, 0.0);
@@ -134,14 +134,14 @@ describe('Chores', async () => {
       expect(preferences.length).to.equal(3);
 
       // Remove the third preference
-      await Admin.updateResident(HOUSE, RESIDENT3, false, '');
+      await Admin.deleteResident(HOUSE, RESIDENT3);
       await sleep(5);
 
       preferences = await Chores.getActiveChorePreferences(HOUSE);
       expect(preferences.length).to.equal(2);
 
       // Restore the third preference
-      await Admin.addResident(HOUSE, RESIDENT3);
+      await Admin.addResident(HOUSE, RESIDENT3, now);
       await sleep(5);
 
       preferences = await Chores.getActiveChorePreferences(HOUSE);
@@ -165,8 +165,8 @@ describe('Chores', async () => {
 
   describe('managing chore values', async () => {
     beforeEach(async () => {
-      await Admin.addResident(HOUSE, RESIDENT1);
-      await Admin.addResident(HOUSE, RESIDENT2);
+      await Admin.addResident(HOUSE, RESIDENT1, now);
+      await Admin.addResident(HOUSE, RESIDENT2, now);
     });
 
     it('can return uniform preferences implicitly', async () => {
@@ -312,10 +312,10 @@ describe('Chores', async () => {
 
   describe('claiming chores', async () => {
     beforeEach(async () => {
-      await Admin.addResident(HOUSE, RESIDENT1);
-      await Admin.addResident(HOUSE, RESIDENT2);
-      await Admin.addResident(HOUSE, RESIDENT3);
-      await Admin.addResident(HOUSE, RESIDENT4);
+      await Admin.addResident(HOUSE, RESIDENT1, now);
+      await Admin.addResident(HOUSE, RESIDENT2, now);
+      await Admin.addResident(HOUSE, RESIDENT3, now);
+      await Admin.addResident(HOUSE, RESIDENT4, now);
     });
 
     it('can claim a chore', async () => {
@@ -626,8 +626,8 @@ describe('Chores', async () => {
 
   describe('managing chore breaks', async () => {
     beforeEach(async () => {
-      await Admin.addResident(HOUSE, RESIDENT1);
-      await Admin.addResident(HOUSE, RESIDENT2);
+      await Admin.addResident(HOUSE, RESIDENT1, now);
+      await Admin.addResident(HOUSE, RESIDENT2, now);
     });
 
     it('can add a chore break', async () => {
@@ -660,7 +660,7 @@ describe('Chores', async () => {
     });
 
     it('can exclude inactive residents from the chore valuing', async () => {
-      await Admin.addResident(HOUSE, RESIDENT3);
+      await Admin.addResident(HOUSE, RESIDENT3, now);
 
       const later = new Date(now.getTime() + 2 * DAY);
 
@@ -679,7 +679,7 @@ describe('Chores', async () => {
       expect(parseInt(residentCount.count)).to.equal(3);
 
       // Will also exclude if inactive
-      await Admin.updateResident(HOUSE, RESIDENT3, false, '');
+      await Admin.deleteResident(HOUSE, RESIDENT3);
       [ residentCount ] = await Chores.getActiveResidentCount(HOUSE, later);
       expect(parseInt(residentCount.count)).to.equal(2);
     });
@@ -747,8 +747,8 @@ describe('Chores', async () => {
 
   describe('managing chore point gifts', async () => {
     beforeEach(async () => {
-      await Admin.addResident(HOUSE, RESIDENT1);
-      await Admin.addResident(HOUSE, RESIDENT2);
+      await Admin.addResident(HOUSE, RESIDENT1, now);
+      await Admin.addResident(HOUSE, RESIDENT2, now);
     });
 
     it('can gift chore points', async () => {

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -324,7 +324,7 @@ describe('Chores', async () => {
         { choreId: dishes.id, valuedAt: now, value: 5, ranking: 0, residents: 0 }
       ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       const choreClaims = await Chores.getValidChoreClaims(dishes.id);
@@ -333,7 +333,7 @@ describe('Chores', async () => {
     });
 
     it('cannot claim a chore with a zero value', async () => {
-      await expect(Chores.claimChore(dishes.id, RESIDENT1, now))
+      await expect(Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now))
         .to.be.rejectedWith('Cannot claim a zero-value chore!');
     });
 
@@ -342,12 +342,12 @@ describe('Chores', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 5, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: soon, value: 20, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT2, soon);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT2, soon);
       await sleep(5);
 
       const choreClaims = await Chores.getValidChoreClaims(dishes.id);
@@ -360,7 +360,7 @@ describe('Chores', async () => {
     it('can successfully resolve a claim', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim ] = await Chores.claimChore(dishes.id, RESIDENT1, now);
+      const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await Polls.submitVote(choreClaim.pollId, RESIDENT1, soon, YAY);
@@ -380,9 +380,9 @@ describe('Chores', async () => {
         { choreId: restock.id, valuedAt: soon, value: 10, ranking: 0, residents: 0 }
       ]);
       await sleep(5);
-      const [ choreClaim1 ] = await Chores.claimChore(dishes.id, RESIDENT1, now);
-      const [ choreClaim2 ] = await Chores.claimChore(sweeping.id, RESIDENT1, now);
-      const [ choreClaim3 ] = await Chores.claimChore(restock.id, RESIDENT1, soon);
+      const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
+      const [ choreClaim2 ] = await Chores.claimChore(HOUSE, sweeping.id, RESIDENT1, now);
+      const [ choreClaim3 ] = await Chores.claimChore(HOUSE, restock.id, RESIDENT1, soon);
       await sleep(5);
 
       // First poll passes, second fails
@@ -414,7 +414,7 @@ describe('Chores', async () => {
     it('cannot resolve a claim before the poll closes ', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim ] = await Chores.claimChore(dishes.id, RESIDENT1, now);
+      const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await expect(Chores.resolveChoreClaim(choreClaim.id, soon))
@@ -424,7 +424,7 @@ describe('Chores', async () => {
     it('cannot resolve a claim twice', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim ] = await Chores.claimChore(dishes.id, RESIDENT1, now);
+      const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await Chores.resolveChoreClaim(choreClaim.id, challengeEnd);
@@ -437,7 +437,7 @@ describe('Chores', async () => {
     it('cannot successfully resolve a claim without two positive votes', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim ] = await Chores.claimChore(dishes.id, RESIDENT1, now);
+      const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await Polls.submitVote(choreClaim.pollId, RESIDENT1, soon, YAY);
@@ -450,7 +450,7 @@ describe('Chores', async () => {
     it('cannot successfully resolve a claim without a passing vote', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim ] = await Chores.claimChore(dishes.id, RESIDENT1, now);
+      const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await Polls.submitVote(choreClaim.pollId, RESIDENT1, soon, YAY);
@@ -472,12 +472,12 @@ describe('Chores', async () => {
 
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t0, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim1 ] = await Chores.claimChore(dishes.id, RESIDENT1, t0);
+      const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, t0);
       await sleep(5);
 
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t1, value: 5, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim2 ] = await Chores.claimChore(dishes.id, RESIDENT2, t1);
+      const [ choreClaim2 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT2, t1);
       await sleep(5);
 
       // Both claims pass
@@ -505,12 +505,12 @@ describe('Chores', async () => {
 
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t0, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim1 ] = await Chores.claimChore(dishes.id, RESIDENT1, t0);
+      const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, t0);
       await sleep(5);
 
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t1, value: 5, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      const [ choreClaim2 ] = await Chores.claimChore(dishes.id, RESIDENT2, t1);
+      const [ choreClaim2 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT2, t1);
       await sleep(5);
 
       // First claim is rejected
@@ -540,8 +540,8 @@ describe('Chores', async () => {
         { choreId: sweeping.id, valuedAt: now, value: 20, ranking: 0, residents: 0 }
       ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
-      await Chores.claimChore(sweeping.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, sweeping.id, RESIDENT1, now);
       await sleep(5);
 
       let chorePoints;
@@ -565,9 +565,9 @@ describe('Chores', async () => {
         { choreId: restock.id, valuedAt: now, value: 89, ranking: 0, residents: 0 }
       ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
-      await Chores.claimChore(sweeping.id, RESIDENT2, now);
-      await Chores.claimChore(restock.id, RESIDENT3, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, sweeping.id, RESIDENT2, now);
+      await Chores.claimChore(HOUSE, restock.id, RESIDENT3, now);
       await sleep(5);
 
       let penalty;
@@ -593,9 +593,9 @@ describe('Chores', async () => {
         { choreId: restock.id, valuedAt: feb1, value: 40, ranking: 0, residents: 0 }
       ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, feb1);
-      await Chores.claimChore(sweeping.id, RESIDENT2, feb1);
-      await Chores.claimChore(restock.id, RESIDENT3, feb1);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, feb1);
+      await Chores.claimChore(HOUSE, sweeping.id, RESIDENT2, feb1);
+      await Chores.claimChore(HOUSE, restock.id, RESIDENT3, feb1);
 
       // Everyone takes half the month off
       await Chores.addChoreBreak(RESIDENT1, feb1, feb15);
@@ -621,7 +621,7 @@ describe('Chores', async () => {
 
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 50, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       let penaltyHeart;
@@ -643,7 +643,7 @@ describe('Chores', async () => {
     it('cannot penalize before initialized', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 50, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       let penaltyHeart;
@@ -812,7 +812,7 @@ describe('Chores', async () => {
     it('can gift chore points', async () => {
       await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
 
       await Chores.giftChorePoints(RESIDENT1, RESIDENT2, now, 6);
@@ -831,9 +831,9 @@ describe('Chores', async () => {
         { choreId: sweeping.id, valuedAt: now, value: 5, ranking: 0, residents: 0 }
       ]);
       await sleep(5);
-      await Chores.claimChore(dishes.id, RESIDENT1, now);
+      await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await sleep(5);
-      await Chores.claimChore(sweeping.id, RESIDENT1, soon);
+      await Chores.claimChore(HOUSE, sweeping.id, RESIDENT1, soon);
       await sleep(5);
 
       const dbError = 'update "ChoreClaim" set "value" = $1 where "id" = $2 - ' +

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -62,9 +62,9 @@ describe('Hearts', async () => {
       await Hearts.generateHearts(HOUSE, RESIDENT2, 1, now);
       await sleep(5);
 
-      const hearts1 = await Hearts.getHearts(HOUSE, RESIDENT1, now);
-      const hearts2 = await Hearts.getHearts(HOUSE, RESIDENT2, now);
-      const hearts3 = await Hearts.getHearts(HOUSE, RESIDENT3, now);
+      const hearts1 = await Hearts.getHearts(RESIDENT1, now);
+      const hearts2 = await Hearts.getHearts(RESIDENT2, now);
+      const hearts3 = await Hearts.getHearts(RESIDENT3, now);
 
       expect(hearts1.sum).to.equal(2);
       expect(hearts2.sum).to.equal(1);
@@ -88,7 +88,7 @@ describe('Hearts', async () => {
       await Hearts.generateHearts(HOUSE, RESIDENT1, -2, now);
       await sleep(5);
 
-      const hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      const hearts = await Hearts.getHearts(RESIDENT1, now);
 
       expect(hearts.sum).to.equal(1);
     });
@@ -98,7 +98,7 @@ describe('Hearts', async () => {
       await Hearts.generateHearts(HOUSE, RESIDENT1, -0.75, now);
       await sleep(5);
 
-      const hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      const hearts = await Hearts.getHearts(RESIDENT1, now);
 
       expect(hearts.sum).to.equal(1.75);
     });
@@ -108,14 +108,14 @@ describe('Hearts', async () => {
       await sleep(5);
 
       let hearts;
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts.sum).to.equal(heartsBaseline);
 
       // But only once
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts.sum).to.equal(heartsBaseline);
 
       // Even if they go back to zero
@@ -125,7 +125,7 @@ describe('Hearts', async () => {
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts.sum).to.equal(0);
     });
 
@@ -136,7 +136,7 @@ describe('Hearts', async () => {
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, nextMonth);
+      hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
       expect(hearts.sum).to.equal(null);
 
       // Generate a heart, now regeneration works
@@ -146,21 +146,21 @@ describe('Hearts', async () => {
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, nextMonth);
+      hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
       expect(hearts.sum).to.equal(1.5);
 
       // But not in the same month
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, nextMonth);
+      hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
       expect(hearts.sum).to.equal(1.5);
 
       // But yes in another month
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, twoMonths);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, twoMonths);
+      hearts = await Hearts.getHearts(RESIDENT1, twoMonths);
       expect(hearts.sum).to.equal(2);
     });
 
@@ -170,26 +170,26 @@ describe('Hearts', async () => {
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts.sum).to.equal(5);
 
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, now);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, now);
+      hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts.sum).to.equal(5);
 
       // Or overloaded
       await Hearts.generateHearts(HOUSE, RESIDENT1, 1, nextMonth);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, nextMonth);
+      hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
       expect(hearts.sum).to.equal(6);
 
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
       await sleep(5);
 
-      hearts = await Hearts.getHearts(HOUSE, RESIDENT1, nextMonth);
+      hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
       expect(hearts.sum).to.equal(6);
     });
   });
@@ -214,8 +214,8 @@ describe('Hearts', async () => {
       await Hearts.resolveChallenge(challenge.id, challengeEnd);
       await sleep(5);
 
-      const hearts1 = await Hearts.getHearts(HOUSE, RESIDENT1, challengeEnd);
-      const hearts2 = await Hearts.getHearts(HOUSE, RESIDENT2, challengeEnd);
+      const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
+      const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
       expect(hearts1.sum).to.equal(5);
       expect(hearts2.sum).to.equal(4);
     });
@@ -232,8 +232,8 @@ describe('Hearts', async () => {
       await Hearts.resolveChallenge(challenge.id, challengeEnd);
       await sleep(5);
 
-      const hearts1 = await Hearts.getHearts(HOUSE, RESIDENT1, challengeEnd);
-      const hearts2 = await Hearts.getHearts(HOUSE, RESIDENT2, challengeEnd);
+      const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
+      const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
       expect(hearts1.sum).to.equal(4);
       expect(hearts2.sum).to.equal(5);
     });
@@ -249,8 +249,8 @@ describe('Hearts', async () => {
       await Hearts.resolveChallenge(challenge.id, challengeEnd);
       await sleep(5);
 
-      const hearts1 = await Hearts.getHearts(HOUSE, RESIDENT1, challengeEnd);
-      const hearts2 = await Hearts.getHearts(HOUSE, RESIDENT2, challengeEnd);
+      const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
+      const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
       expect(hearts1.sum).to.equal(4);
       expect(hearts2.sum).to.equal(5);
     });
@@ -270,8 +270,8 @@ describe('Hearts', async () => {
       await Hearts.resolveChallenges(HOUSE, challengeEnd);
       await sleep(5);
 
-      const hearts1 = await Hearts.getHearts(HOUSE, RESIDENT1, challengeEnd);
-      const hearts2 = await Hearts.getHearts(HOUSE, RESIDENT2, challengeEnd);
+      const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
+      const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
       expect(hearts1.sum).to.equal(4);
       expect(hearts2.sum).to.equal(4);
     });

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -32,17 +32,17 @@ describe('Hearts', async () => {
     await db('Resident').del();
     await db('House').del();
 
-    await Admin.updateHouse({ slackId: HOUSE });
-    await Admin.addResident(HOUSE, RESIDENT1);
-    await Admin.addResident(HOUSE, RESIDENT2);
-    await Admin.addResident(HOUSE, RESIDENT3);
-    await Admin.addResident(HOUSE, RESIDENT4);
-    await Admin.addResident(HOUSE, RESIDENT5);
-
     now = new Date();
     challengeEnd = new Date(now.getTime() + heartsPollLength);
     nextMonth = getNextMonthStart(now);
     twoMonths = getNextMonthStart(nextMonth);
+
+    await Admin.updateHouse({ slackId: HOUSE });
+    await Admin.addResident(HOUSE, RESIDENT1, now);
+    await Admin.addResident(HOUSE, RESIDENT2, now);
+    await Admin.addResident(HOUSE, RESIDENT3, now);
+    await Admin.addResident(HOUSE, RESIDENT4, now);
+    await Admin.addResident(HOUSE, RESIDENT5, now);
   });
 
   afterEach(async () => {

--- a/test/polls.test.js
+++ b/test/polls.test.js
@@ -26,13 +26,13 @@ describe('Polls', async () => {
     await db('Resident').del();
     await db('House').del();
 
-    await Admin.updateHouse({ slackId: HOUSE });
-    await Admin.addResident(HOUSE, RESIDENT1);
-    await Admin.addResident(HOUSE, RESIDENT2);
-    await Admin.addResident(HOUSE, RESIDENT3);
-
     now = new Date();
     soon = new Date(now.getTime() + HOUR);
+
+    await Admin.updateHouse({ slackId: HOUSE });
+    await Admin.addResident(HOUSE, RESIDENT1, now);
+    await Admin.addResident(HOUSE, RESIDENT2, now);
+    await Admin.addResident(HOUSE, RESIDENT3, now);
   });
 
   afterEach(async () => {

--- a/test/things.test.js
+++ b/test/things.test.js
@@ -33,14 +33,14 @@ describe('Things', async () => {
     await db('Resident').del();
     await db('House').del();
 
-    await Admin.updateHouse({ slackId: HOUSE });
-    await Admin.addResident(HOUSE, RESIDENT1);
-    await Admin.addResident(HOUSE, RESIDENT2);
-    await Admin.addResident(HOUSE, RESIDENT3);
-
     now = new Date();
     soon = new Date(now.getTime() + HOUR);
     challengeEnd = new Date(now.getTime() + thingsPollLength);
+
+    await Admin.updateHouse({ slackId: HOUSE });
+    await Admin.addResident(HOUSE, RESIDENT1, now);
+    await Admin.addResident(HOUSE, RESIDENT2, now);
+    await Admin.addResident(HOUSE, RESIDENT3, now);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Closes #10 
Closes #16 

- Set `activeAt` when adding a resident, use this to decrease points owed in the month that a resident is added.
- Fix the resolved flow in Things, Chores, and Hearts
- Properly implemented quorums for Hearts challenges
- Clean up some redundant slash commands.